### PR TITLE
Mob tool moved to *before* task

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@
 ---
 # Commands to start on workspace startup
 tasks:
-  - init: |
+  - before: |
       # Install mob tool.
       curl -sL install.mob.sh | sh -s - --user
       alias mob=/home/gitpod/.local/bin/mob


### PR DESCRIPTION
Mob tool installation initialized in gitpod *before* task.